### PR TITLE
Added non-blocking (async/await) APIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: rust
+
+script:
+  - cargo build --verbose --all-features
+  - cargo test --verbose --all-features
+
 notifications:
   email:
     on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,22 @@
 language: rust
 
+rust:
+  stable
+  nightly
+
+jobs:
+  include:
+    - rust: stable
+      env: FLAGS=""
+    - rust: nightly
+      env: FLAGS="--all-features"
+
 script:
-  - cargo build --verbose --all-features
-  - cargo test --verbose --all-features
+  - cargo build $FLAGS
+  - cargo test $FLAGS
 
 notifications:
   email:
     on_success: never
     on_failure: never
+  

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,24 @@ description = "Generic traits for embedded packet radio devices"
 repository = "https://github.com/ryankurte/rust-radio"
 authors = ["Ryan Kurte <ryankurte@gmail.com>"]
 license = "MIT"
+edition = "2018"
 version = "0.4.1"
+
+[features]
+async-await = [ "core", "async-std" ]
+default = []
 
 [dependencies]
 nb = "0.1.2"
 log = "0.4.6"
 embedded-hal = "0.2.3"
+async-trait = "0.1.22"
 
+[dependencies.core]
+package = "core-futures-tls"
+version = "0.1.0"
+optional = true
+
+[dependencies.async-std]
+version = "*"
+optional = true

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 An [embedded-hal](https://github.com/rust-embedded/embedded-hal) like abstraction for digital radio devices, this is intended to provide a common basis for implementing packet radio drivers, and for extension to support 802.15.4 / BLE etc. in the hope that we can construct embedded network stacks using this common abstraction.
 
+Radio devices should implement the core traits, and then gain automatic [blocking]() helper functions.
+
+Experimental async/await helpers are available behind the `async-await` feature flag.
 
 ## Status
 
@@ -18,10 +21,12 @@ An [embedded-hal](https://github.com/rust-embedded/embedded-hal) like abstractio
 
 - [x] Transmit
 - [x] Receive
+- [x] Set Channel
 - [x] Fetch RSSI
 - [x] Register Access
 - [ ] Configuration
 - [ ] 802.15.4
+
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An [embedded-hal](https://github.com/rust-embedded/embedded-hal) like abstractio
 
 Radio devices should implement the core traits, and then gain automatic [blocking]() helper functions.
 
-Experimental async/await helpers are available behind the `async-await` feature flag.
+Experimental async/await helpers are available behind the `async-await` feature flag, and requires nightly for compilation.
 
 ## Status
 

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -1,3 +1,7 @@
+//! Blocking APIs on top of the base radio traits
+//! 
+//! https://github.com/ryankurte/rust-radio
+//! Copyright 2020 Ryan Kurte
 
 use core::time::Duration;
 
@@ -33,7 +37,8 @@ impl <E> From<E> for BlockingError<E> {
     }
 }
 
-/// Blocking transmit function implemented over `radio::Transmit` and `radio::Power` using the provided `DelayMs` impl to poll for completion
+/// Blocking transmit function implemented over `radio::Transmit` and `radio::Power` using the provided 
+/// `BlockingOptions` and radio-internal `DelayMs` impl to poll for completion
 pub trait BlockingTransmit<E> {
     fn do_transmit(&mut self, data: &[u8], tx_options: BlockingOptions) -> Result<(), BlockingError<E>>;
 }
@@ -72,7 +77,8 @@ where
     }
 }
 
-/// Blocking receive function implemented over `radio::Receive` using the provided `DelayMs` impl to poll for completion
+/// Blocking receive function implemented over `radio::Receive` using the provided `BlockingOptions` 
+/// and radio-internal `DelayMs` impl to poll for completion
 pub trait BlockingReceive<I, E> {
     fn do_receive(&mut self, buff: &mut [u8], info: &mut I, rx_options: BlockingOptions) -> Result<usize, BlockingError<E>>;
 }
@@ -146,3 +152,4 @@ where
 
     }
 }
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,7 @@
 //! Abstract packet radio interfaces
 //! 
-//! https://github.com/rust-iot/radio
-//! 
-// Copyright 2018 Ryan Kurte
+//! https://github.com/ryankurte/rust-radio
+// Copyright 2020 Ryan Kurte
 
 #![no_std]
 #![deny(unsafe_code)]
@@ -14,7 +13,13 @@ extern crate log;
 
 extern crate embedded_hal;
 
+//#[cfg(feature="async-await")]
+extern crate async_trait;
+
 pub mod blocking;
+
+#[cfg(feature="async-await")]
+pub mod nonblocking;
 
 /// Radio trait combines Base, Configure, Send and Receive for a generic radio object
 pub trait Radio: Transmit + Receive {}
@@ -59,7 +64,7 @@ pub trait Receive {
     /// 
     /// This copies received data into the provided buffer and returns the number of bytes received
     /// as well as information about the received packet
-    fn get_received<'a>(&mut self, &mut Self::Info, &'a mut [u8]) -> Result<usize, Self::Error>;
+    fn get_received(&mut self, info: &mut Self::Info, buff: &mut [u8]) -> Result<usize, Self::Error>;
 }
 
 /// Default / Standard packet information structure for radio devices that provide only rssi 

--- a/src/nonblocking.rs
+++ b/src/nonblocking.rs
@@ -1,0 +1,169 @@
+//! Non-blocking APIs on top of the base radio traits
+//! Note that this _requires_ (and will include) std
+//! 
+//! https://github.com/ryankurte/rust-radio
+//! Copyright 2020 Ryan Kurte
+
+
+use core::future::Future;
+use core::marker::PhantomData;
+use core::task::{Context, Poll, Waker};
+use core::pin::Pin;
+
+// std required for async-trait
+extern crate std;
+use std::boxed::Box;
+use async_trait::async_trait;
+
+extern crate async_std;
+
+use embedded_hal::blocking::delay::DelayMs;
+use crate::{Transmit, Receive, Power};
+
+pub struct AsyncOptions {
+    pub power: Option<i8>,
+}
+
+impl Default for AsyncOptions {
+    fn default() -> Self {
+        Self {            
+            power: None,
+        }
+    }
+}
+
+/// Async transmit function implemented over `radio::Transmit` and `radio::Power` using the provided 
+/// `AsyncOptions`
+#[async_trait]
+pub trait AsyncTransmit<E> {
+    async fn async_transmit(&mut self, data: &[u8], tx_options: AsyncOptions) -> Result<(), E>;
+}
+
+#[async_trait]
+impl <T, E: 'static> AsyncTransmit<E> for T
+where
+    T: Transmit<Error = E> + Power<Error = E> + DelayMs<u32> + Send,
+    E: core::fmt::Debug + Send + Unpin,
+{
+    async fn async_transmit(&mut self, data: &[u8], tx_options: AsyncOptions) -> Result<(), E> {
+        // Set output power if specified
+        if let Some(p) = tx_options.power {
+            self.set_power(p)?;
+        }
+
+        // Start transmission
+        self.start_transmit(data)?;
+
+        // Create transmit future
+        let f: TransmitFuture<_, E> = TransmitFuture{radio: self, waker: None, _err: PhantomData};
+
+        // Await on transmission
+        let res = f.await?;
+
+        // Return result
+        Ok(res)
+    }
+}
+
+pub struct TransmitFuture<'a, T, E> {
+    radio: &'a mut T,
+    waker: Option<Waker>,
+    _err: PhantomData<E>,
+}
+
+impl <'a, T, E> Future for TransmitFuture<'a, T, E> 
+where 
+    T: Transmit<Error = E> + Power<Error = E> + DelayMs<u32> + Send,
+    E: core::fmt::Debug + Send + Unpin,
+{
+    type Output = Result<(), E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let s = self.get_mut();
+
+        // Check for completion
+        if s.radio.check_transmit()? {
+            return Poll::Ready(Ok(()))
+        };
+        
+        // TODO: we don't _strictly_ need to wake every time?
+        // but for now, we're going to
+        cx.waker().clone().wake();
+
+        // Store for later (probably not required with above)
+        s.waker = Some(cx.waker().clone());
+
+        // Indicate there is still work to be done
+        Poll::Pending
+    }
+}
+
+/// Async transmit function implemented over `radio::Transmit` and `radio::Power` using the provided 
+/// `AsyncOptions`
+#[async_trait]
+pub trait AsyncReceive<I, E> {
+    async fn async_receive(&mut self, info: &mut I, buff: &mut [u8], rx_options: AsyncOptions) -> Result<usize, E>;
+}
+
+#[async_trait]
+impl <T, I, E: 'static> AsyncReceive<I, E> for T
+where
+    T: Receive<Error = E, Info = I> + DelayMs<u32> + Send,
+    I: core::fmt::Debug + Send,
+    E: core::fmt::Debug + Send + Unpin,
+{
+    async fn async_receive(&mut self, info: &mut I, buff: &mut [u8], _rx_options: AsyncOptions) -> Result<usize, E> {
+        // Start receive mode
+        self.start_receive()?;
+
+        // Create receive future
+        let f: ReceiveFuture<_, I, E> = ReceiveFuture {
+            radio: self, info, buff, waker: None, _err: PhantomData
+        };
+
+        // Await completion
+        let r = f.await?;
+
+        // Return result
+        Ok(r)
+    }
+}
+
+pub struct ReceiveFuture<'a, T, I, E> {
+    radio: &'a mut T,
+    info: &'a mut I,
+    buff: &'a mut [u8],
+    waker: Option<Waker>,
+    _err: PhantomData<E>,
+}
+
+impl <'a, T, I, E> Future for ReceiveFuture<'a, T, I, E> 
+where 
+    T: Receive<Error = E, Info = I> + DelayMs<u32> + Send,
+    I: core::fmt::Debug + Send,
+    E: core::fmt::Debug + Send + Unpin,
+{
+    type Output = Result<usize, E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let s = self.get_mut();
+
+        // Check for completion
+        if s.radio.check_receive(true)? {
+            // Retrieve data
+            let n = s.radio.get_received(s.info, s.buff)?;
+
+            return Poll::Ready(Ok(n));
+        }
+
+        // TODO: we don't _strictly_ need to wake every time?
+        // but for now, we're going to
+        cx.waker().clone().wake();
+
+        // Store for later (probably not required with above)
+        s.waker = Some(cx.waker().clone());
+
+        // Indicate there is still work to be done
+        Poll::Pending
+    }
+}


### PR DESCRIPTION
This currently requires std as well as workarounds for the [futures tls issue with no_std](https://github.com/rust-lang/rust/issues/56974) and as such is accessible behind a feature flag.