### PR TITLE
Add generic parameters to Transmit and Receive

### DIFF
--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -17,6 +17,7 @@ use structopt::StructOpt;
 use crate::std::string::ToString;
 
 use crate::{Transmit, Receive, State};
+use crate::params::Param;
 
 /// BlockingOptions for blocking radio functions
 #[derive(Clone, PartialEq, Debug)]
@@ -151,17 +152,17 @@ assert_eq!(&buff[..data.len()], &data);
 ```
 "##)]
 /// 
-pub trait BlockingReceive<P, I, E> {
-    fn do_receive(&mut self, buff: &mut [u8], params: &P, info: &mut I, rx_options: BlockingOptions) -> Result<usize, BlockingError<E>>;
+pub trait BlockingReceive<P: Param, E> {
+    fn do_receive(&mut self, buff: &mut [u8], params: &P, info: &mut P::Info, rx_options: BlockingOptions) -> Result<usize, BlockingError<E>>;
 }
 
-impl <T, P, I, E> BlockingReceive<P, I, E> for T
+impl <T, P, E> BlockingReceive<P, E> for T
 where
-    T: Receive<P, Info=I, Error=E> + DelayUs<u32>,
-    I: core::fmt::Debug,
+    T: Receive<P, Error=E> + DelayUs<u32>,
+    P: Param,
     E: core::fmt::Debug,
 {
-    fn do_receive(&mut self, buff: &mut [u8], params: &P, info: &mut I, rx_options: BlockingOptions) -> Result<usize, BlockingError<E>> {
+    fn do_receive(&mut self, buff: &mut [u8], params: &P, info: &mut P::Info, rx_options: BlockingOptions) -> Result<usize, BlockingError<E>> {
         // Start receive mode
         self.start_receive(params)?;
 

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -60,6 +60,7 @@ impl <E> From<E> for BlockingError<E> {
 # use radio::*;
 # use radio::mock::*;
 use radio::blocking::{BlockingTransmit, BlockingOptions};
+use radio::params::Basic;
 
 # let mut radio = MockRadio::new(&[
 #    Transaction::start_transmit(vec![0xaa, 0xbb], None),
@@ -69,7 +70,7 @@ use radio::blocking::{BlockingTransmit, BlockingOptions};
 # ]);
 # 
 // Transmit using a blocking call
-let res = radio.do_transmit(&[0xaa, 0xbb], BlockingOptions::default());
+let res = radio.do_transmit(&[0xaa, 0xbb], &Basic, BlockingOptions::default());
 
 assert_eq!(res, Ok(()));
 
@@ -121,6 +122,7 @@ where
 # use radio::*;
 # use radio::mock::*;
 use radio::blocking::{BlockingReceive, BlockingOptions};
+use radio::params::Basic;
 
 let data = [0xaa, 0xbb];
 let info = BasicInfo::new(-81, 0);
@@ -136,10 +138,11 @@ let info = BasicInfo::new(-81, 0);
 # 
 
 let mut buff = [0u8; 128];
+let params = Basic;
 let mut i = BasicInfo::new(0, 0);
 
 // Receive using a blocking call
-let res = radio.do_receive(&mut buff, &mut i, BlockingOptions::default());
+let res = radio.do_receive(&mut buff, &params, &mut i, BlockingOptions::default());
 
 assert_eq!(res, Ok(data.len()));
 assert_eq!(&buff[..data.len()], &data);

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -77,18 +77,18 @@ assert_eq!(res, Ok(()));
 ```
 "##)]
 ///
-pub trait BlockingTransmit<E> {
-    fn do_transmit(&mut self, data: &[u8], tx_options: BlockingOptions) -> Result<(), BlockingError<E>>;
+pub trait BlockingTransmit<P, E> {
+    fn do_transmit(&mut self, data: &[u8], params: &P, tx_options: BlockingOptions) -> Result<(), BlockingError<E>>;
 }
 
-impl <T, E> BlockingTransmit<E> for T
+impl <T, P, E> BlockingTransmit<P, E> for T
 where 
-    T: Transmit<Error = E> + DelayUs<u32>,
+    T: Transmit<P, Error = E> + DelayUs<u32>,
     E: core::fmt::Debug,
 {
-    fn do_transmit(&mut self, data: &[u8], tx_options: BlockingOptions) -> Result<(), BlockingError<E>> {
+    fn do_transmit(&mut self, data: &[u8], params: &P, tx_options: BlockingOptions) -> Result<(), BlockingError<E>> {
         // Enter transmit mode
-        self.start_transmit(data)?;
+        self.start_transmit(data, params)?;
 
         let t = tx_options.timeout.as_micros();
         let mut c = 0;
@@ -148,19 +148,19 @@ assert_eq!(&buff[..data.len()], &data);
 ```
 "##)]
 /// 
-pub trait BlockingReceive<I, E> {
-    fn do_receive(&mut self, buff: &mut [u8], info: &mut I, rx_options: BlockingOptions) -> Result<usize, BlockingError<E>>;
+pub trait BlockingReceive<P, I, E> {
+    fn do_receive(&mut self, buff: &mut [u8], params: &P, info: &mut I, rx_options: BlockingOptions) -> Result<usize, BlockingError<E>>;
 }
 
-impl <T, I, E> BlockingReceive<I, E> for T 
+impl <T, P, I, E> BlockingReceive<P, I, E> for T
 where
-    T: Receive<Info=I, Error=E> + DelayUs<u32>,
+    T: Receive<P, Info=I, Error=E> + DelayUs<u32>,
     I: core::fmt::Debug,
     E: core::fmt::Debug,
 {
-    fn do_receive(&mut self, buff: &mut [u8], info: &mut I, rx_options: BlockingOptions) -> Result<usize, BlockingError<E>> {
+    fn do_receive(&mut self, buff: &mut [u8], params: &P, info: &mut I, rx_options: BlockingOptions) -> Result<usize, BlockingError<E>> {
         // Start receive mode
-        self.start_receive()?;
+        self.start_receive(params)?;
 
         let t = rx_options.timeout.as_micros();
         let mut c = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,20 +32,20 @@ pub mod helpers;
 pub mod mock;
 
 /// Radio trait combines Base, Configure, Send and Receive for a generic radio object
-pub trait Radio: Transmit + Receive + State {}
+pub trait Radio<P>: Transmit<P> + Receive<P> + State {}
 
 /// Transmit trait for radios that can transmit packets
 /// 
 /// `start_transmit` should be called to load data into the radio, with `check_transmit` called
 /// periodically (or using interrupts) to continue and finalise the transmission.
-pub trait Transmit {
+pub trait Transmit<P> {
     /// Radio error
     type Error;
 
     /// Start sending a packet on the provided channel
     /// 
     /// Returns an error if send was not started
-    fn start_transmit(&mut self, data: &[u8]) -> Result<(), Self::Error>;
+    fn start_transmit(&mut self, data: &[u8], params: &P) -> Result<(), Self::Error>;
 
     /// Check for send completion
     /// 
@@ -58,7 +58,7 @@ pub trait Transmit {
 /// `start_receive` should be used to setup the radio in receive mode, with `check_receive` called
 /// periodically (or using interrupts) to poll for packet reception. Once a packet has been received,
 /// `get_received` fetches the received packet (and associated info) from the radio.
-pub trait Receive {
+pub trait Receive<P> {
     /// Radio error
     type Error;
     /// Packet received info
@@ -67,7 +67,7 @@ pub trait Receive {
     /// Set receiving on the specified channel
     /// 
     /// Returns an error if receive mode was not entered
-    fn start_receive(&mut self) -> Result<(), Self::Error>;
+    fn start_receive(&mut self, params: &P) -> Result<(), Self::Error>;
 
     /// Check for reception
     /// 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub mod helpers;
 pub mod mock;
 
 /// Radio trait combines Base, Configure, Send and Receive for a generic radio object
-pub trait Radio<P>: Transmit<P> + Receive<P> + State {}
+pub trait Radio<P: Param>: Transmit<P> + Receive<P> + State {}
 
 /// Transmit trait for radios that can transmit packets
 /// 
@@ -59,11 +59,9 @@ pub trait Transmit<P> {
 /// `start_receive` should be used to setup the radio in receive mode, with `check_receive` called
 /// periodically (or using interrupts) to poll for packet reception. Once a packet has been received,
 /// `get_received` fetches the received packet (and associated info) from the radio.
-pub trait Receive<P> {
+pub trait Receive<P: Param> {
     /// Radio error
     type Error;
-    /// Packet received info
-    type Info;
 
     /// Set receiving on the specified channel
     /// 
@@ -82,7 +80,7 @@ pub trait Receive<P> {
     /// 
     /// This copies received data into the provided buffer and returns the number of bytes received
     /// as well as information about the received packet
-    fn get_received(&mut self, info: &mut Self::Info, buff: &mut [u8]) -> Result<usize, Self::Error>;
+    fn get_received(&mut self, info: &mut P::Info, buff: &mut [u8]) -> Result<usize, Self::Error>;
 }
 
 /// ReceiveInfo trait for receive information objects
@@ -246,6 +244,7 @@ pub trait Registers<R: Copy> {
     }
 }
 
+use crate::params::Param;
 #[cfg(feature="structopt")]
 use crate::std::str::FromStr;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,13 +16,14 @@ extern crate log;
 
 extern crate embedded_hal;
 
-
 #[cfg(feature="std")]
 extern crate std;
 
 pub mod config;
 
 pub mod blocking;
+
+pub mod params;
 
 #[cfg(feature="nonblocking")]
 pub mod nonblocking;

--- a/src/nonblocking.rs
+++ b/src/nonblocking.rs
@@ -11,19 +11,20 @@ use core::task::{Context, Poll};
 use core::pin::Pin;
 
 use crate::{Transmit, Receive, Power};
+use crate::params::Param;
 
 /// Options for async driver calls
 pub struct AsyncOptions {
     /// Power option, for transmit operations
     pub power: Option<i8>,
-    
+
     /// Timeout option for underlying radio operations
     #[deprecated(note = "Timeouts must (currently) be implemented outside this module")]
     pub timeout: Option<Duration>,
-    
+
     /// Period for polling on operation status with custom wakers
     pub poll_period: Duration,
-    
+
     /// Waker function to be called in the `Poll` method
     pub wake_fn: Option<&'static fn(cx: &mut Context, d: Duration)>,
 }
@@ -31,7 +32,7 @@ pub struct AsyncOptions {
 impl Default for AsyncOptions {
     #[allow(deprecated)]
     fn default() -> Self {
-        Self {            
+        Self {
             power: None,
             timeout: None,
             poll_period: Duration::from_millis(10),
@@ -54,7 +55,7 @@ impl <E> From<E> for AsyncError<E> {
 }
 
 /// Async transmit function implemented over `radio::Transmit` and `radio::Power` using the provided `AsyncOptions`
-/// 
+///
 #[cfg_attr(feature = "mock", doc = r##"
 ```
 extern crate async_std;
@@ -81,7 +82,7 @@ assert_eq!(res, Ok(()));
 ```
 "##)]
 
-/// AsyncTransmit function provides an async implementation for transmitting packets 
+/// AsyncTransmit function provides an async implementation for transmitting packets
 pub trait AsyncTransmit<'a, P, E> {
     type Output: Future<Output=Result<(), AsyncError<E>>>;
 
@@ -130,7 +131,7 @@ where
 
 
 impl <'a, T, P, E> Future for TransmitFuture<'a, T, P, E>
-where 
+where
     T: Transmit<P, Error = E> + Power<Error = E>,
     E: core::fmt::Debug + Unpin,
 {
@@ -144,7 +145,7 @@ where
         if s.radio.check_transmit()? {
             return Poll::Ready(Ok(()))
         };
-        
+
         // Spawn task to re-execute waker
         if let Some(w) = s.options.wake_fn {
             w(cx, period);
@@ -159,7 +160,7 @@ where
 
 
 /// Async transmit function implemented over `radio::Transmit` and `radio::Power` using the provided `AsyncOptions`
-/// 
+///
 #[cfg_attr(feature = "mock", doc = r##"
 ```
 extern crate async_std;
@@ -197,17 +198,17 @@ assert_eq!(&buff[..data.len()], &data);
 "##)]
 
 /// AsyncReceive trait support futures-based polling on receive
-pub trait AsyncReceive<'a, P, I, E> {
+pub trait AsyncReceive<'a, P: Param, E> {
     type Output: Future<Output=Result<usize, AsyncError<E>>>;
 
-    fn async_receive(&'a mut self, params: &'a P, info: &'a mut I, buff: &'a mut [u8], rx_options: AsyncOptions) -> Result<Self::Output, E>;
+    fn async_receive(&'a mut self, params: &'a P, info: &'a mut P::Info, buff: &'a mut [u8], rx_options: AsyncOptions) -> Result<Self::Output, E>;
 }
 
 /// Receive future wraps a radio and buffer to provide a pollable future for receiving packets
-pub struct ReceiveFuture<'a, T, P, I, E> {
+pub struct ReceiveFuture<'a, T, P: Param, E> {
     radio: &'a mut T,
     params: &'a P,
-    info: &'a mut I,
+    info: &'a mut P::Info,
     buff: &'a mut [u8],
     options: AsyncOptions,
     _err: PhantomData<E>,
@@ -215,25 +216,24 @@ pub struct ReceiveFuture<'a, T, P, I, E> {
 
 
 /// Generic implementation of `AsyncReceive` for all `Receive` capable radio devices
-impl <'a, T, P, I, E> AsyncReceive<'a, P, I, E> for T
+impl <'a, T, P, E> AsyncReceive<'a, P, E> for T
 where
-    T: Receive<P, Error = E, Info = I> + 'a,
-    P: 'a,
-    I: core::fmt::Debug + 'a,
+    T: Receive<P, Error = E> + 'a,
+    P: Param + 'a,
     E: core::fmt::Debug + Unpin,
 {
-    type Output = ReceiveFuture<'a, T, P, I, E>;
+    type Output = ReceiveFuture<'a, T, P, E>;
 
-    fn async_receive(&'a mut self, params: &'a P, info: &'a mut I, buff: &'a mut [u8], rx_options: AsyncOptions) -> Result<Self::Output, E> {
+    fn async_receive(&'a mut self, params: &'a P, info: &'a mut P::Info, buff: &'a mut [u8], rx_options: AsyncOptions) -> Result<Self::Output, E> {
         // Start receive mode
         self.start_receive(params)?;
 
         // Create receive future
-        let f: ReceiveFuture<_, P, I, E> = ReceiveFuture {
+        let f: ReceiveFuture<_, P, E> = ReceiveFuture {
             radio: self,
             params,
-            info, 
-            buff, 
+            info,
+            buff,
             options: rx_options,
             _err: PhantomData
         };
@@ -242,10 +242,10 @@ where
     }
 }
 
-impl <'a, T, P, I, E> Future for ReceiveFuture<'a, T, P, I, E>
-where 
-    T: Receive<P, Error = E, Info = I>,
-    I: core::fmt::Debug,
+impl <'a, T, P, E> Future for ReceiveFuture<'a, T, P, E>
+where
+    T: Receive<P, Error = E>,
+    P: Param,
     E: core::fmt::Debug + Unpin,
 {
     type Output = Result<usize, AsyncError<E>>;

--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -1,0 +1,2 @@
+/// No parameters necessary, for `Transmit<Basic>` and `Receive<Basic>`
+pub struct Basic;

--- a/src/params/mod.rs
+++ b/src/params/mod.rs
@@ -1,2 +1,16 @@
+use core::fmt::Debug;
+
+use crate::{BasicInfo, ReceiveInfo};
+
+/// The parameters of types of packages
+pub trait Param {
+    /// Packet received info
+    type Info: ReceiveInfo + Debug;
+}
+
 /// No parameters necessary, for `Transmit<Basic>` and `Receive<Basic>`
 pub struct Basic;
+
+impl Param for Basic {
+    type Info = BasicInfo;
+}


### PR DESCRIPTION
This pull request adds generic parameters to the `Transmit` and `Receive` traits. It would allow the same radio to, for instance, implement both `Transmit<LoRa>` and `Transmit<Fsk>`, each with different types of parameters for transmitting. The issue ivajloip/rust-lorawan#50 describes a use case for it. It is an early work in progress, but please let me know whether you think this is something worth pursuing! :slightly_smiling_face: 