### PR TITLE
Swap to associated trait bounds where viable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ async-std = { version = "1.4.0", optional = true }
 libc = { version = "0.2.71", optional = true }
 byteorder = { version = "1.3.4", optional = true }
 rolling-stats = { version = "0.3.0", optional = true }
-
+thiserror = { version = "1.0.30", optional = true }
 
 [dependencies.chrono]
 version = "0.4.19"
@@ -39,3 +39,5 @@ default_features = false
 version = "0.7.1"
 optional = true
 
+[dev-dependencies]
+anyhow = "1.0.44"

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,7 +24,6 @@ pub enum ConfigOption {
     /// Transmit power (dBm)
     TXPower(i16),
 
-
     /// Await Clear Channel before TX (if supported)
     AwaitCCA(bool),
     /// CCA threshold in dBm (used if AwaitCCA is set)
@@ -45,7 +44,7 @@ pub enum ConfigError<E> {
     NotSupported,
 
     /// Other (device, non-configuration errors)
-    Other(E)
+    Other(E),
 }
 
 /// Configure trait implemented by configurable radios
@@ -62,4 +61,3 @@ pub trait Configure {
     /// Returns Ok(true) on successful get, Ok(false) for unsupported options, Err(Self::Error) for errors
     fn get_option(&mut self, o: &mut ConfigOption) -> Result<(), ConfigError<Self::Error>>;
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,105 +1,106 @@
 //! Abstract packet radio interfaces
-//! 
+//!
 //! This package defines traits for packet radio devices, as well as blocking and async
 //! implementations using these traits, and a mock device to support application level testing.
-//! 
+//!
 //! ## https://github.com/ryankurte/rust-radio
 //! ## Copyright 2020 Ryan Kurte
 
 #![no_std]
 
-extern crate nb;
+use core::fmt::Debug;
+
 extern crate chrono;
+extern crate nb;
 
 #[macro_use]
 extern crate log;
 
 extern crate embedded_hal;
 
-
-#[cfg(feature="std")]
+#[cfg(feature = "std")]
 extern crate std;
 
 pub mod config;
 
 pub mod blocking;
 
-#[cfg(feature="nonblocking")]
-pub mod nonblocking;
-#[cfg(feature="helpers")]
+#[cfg(feature = "helpers")]
 pub mod helpers;
-#[cfg(feature="mock")]
+#[cfg(feature = "mock")]
 pub mod mock;
+#[cfg(feature = "nonblocking")]
+pub mod nonblocking;
 
 /// Radio trait combines Base, Configure, Send and Receive for a generic radio object
 pub trait Radio: Transmit + Receive + State {}
 
 /// Transmit trait for radios that can transmit packets
-/// 
+///
 /// `start_transmit` should be called to load data into the radio, with `check_transmit` called
 /// periodically (or using interrupts) to continue and finalise the transmission.
 pub trait Transmit {
     /// Radio error
-    type Error;
+    type Error: Debug;
 
     /// Start sending a packet on the provided channel
-    /// 
+    ///
     /// Returns an error if send was not started
     fn start_transmit(&mut self, data: &[u8]) -> Result<(), Self::Error>;
 
     /// Check for send completion
-    /// 
+    ///
     /// Returns true for send complete, false otherwise
     fn check_transmit(&mut self) -> Result<bool, Self::Error>;
 }
 
 /// Receive trait for radios that can receive packets
-/// 
+///
 /// `start_receive` should be used to setup the radio in receive mode, with `check_receive` called
 /// periodically (or using interrupts) to poll for packet reception. Once a packet has been received,
 /// `get_received` fetches the received packet (and associated info) from the radio.
 pub trait Receive {
     /// Radio error
-    type Error;
+    type Error: Debug;
     /// Packet received info
-    type Info;
+    type Info: ReceiveInfo;
 
     /// Set receiving on the specified channel
-    /// 
+    ///
     /// Returns an error if receive mode was not entered
     fn start_receive(&mut self) -> Result<(), Self::Error>;
 
     /// Check for reception
-    /// 
+    ///
     /// The restart flag indicates on (recoverable) error conditions (such as invalid CRC)
     /// the radio should re-enter receive mode if required and continue reception.
-    /// 
+    ///
     /// This returns true for received, false for not received, or the provided error
     fn check_receive(&mut self, restart: bool) -> Result<bool, Self::Error>;
 
     /// Fetch a received packet if rx is complete
-    /// 
+    ///
     /// This copies received data into the provided buffer and returns the number of bytes received
     /// as well as information about the received packet
-    fn get_received(&mut self, info: &mut Self::Info, buff: &mut [u8]) -> Result<usize, Self::Error>;
+    fn get_received(&mut self, buff: &mut [u8]) -> Result<(usize, Self::Info), Self::Error>;
 }
 
 /// ReceiveInfo trait for receive information objects
-/// 
+///
 /// This sup[ports the constraint of generic `Receive::Info`, allowing generic middleware
 /// to access the rssi of received packets
-pub trait ReceiveInfo {
+pub trait ReceiveInfo: Debug + Default {
     fn rssi(&self) -> i16;
 }
 
-/// Default / Standard packet information structure for radio devices that provide only rssi 
+/// Default / Standard packet information structure for radio devices that provide only rssi
 /// and lqi information
 #[derive(Debug, Clone, PartialEq)]
 pub struct BasicInfo {
     /// Received Signal Strength Indicator (RSSI) of received packet in dBm
-    rssi:   i16,
+    rssi: i16,
     /// Link Quality Indicator (LQI) of received packet  
-    lqi:    u16,
+    lqi: u16,
 }
 
 impl Default for BasicInfo {
@@ -113,7 +114,7 @@ impl Default for BasicInfo {
 
 impl BasicInfo {
     pub fn new(rssi: i16, lqi: u16) -> Self {
-        Self {rssi, lqi}
+        Self { rssi, lqi }
     }
 }
 
@@ -126,7 +127,7 @@ impl ReceiveInfo for BasicInfo {
 
 /// Default / Standard radio channel object for radio devices with integer channels
 #[derive(Debug, Clone, PartialEq)]
-pub struct BasicChannel (pub u16);
+pub struct BasicChannel(pub u16);
 
 impl From<u16> for BasicChannel {
     fn from(u: u16) -> Self {
@@ -143,9 +144,9 @@ impl Into<u16> for BasicChannel {
 /// Channel trait for configuring radio channelization
 pub trait Channel {
     /// Channel information
-    type Channel;
+    type Channel: Debug;
     /// Radio error type
-    type Error;
+    type Error: Debug;
 
     /// Set the radio channel for future transmit and receive operations
     fn set_channel(&mut self, channel: &Self::Channel) -> Result<(), Self::Error>;
@@ -154,19 +155,19 @@ pub trait Channel {
 /// Power trait for configuring radio power
 pub trait Power {
     /// Radio error type
-    type Error;
+    type Error: Debug;
 
     /// Set the radio power in dBm
     fn set_power(&mut self, power: i8) -> Result<(), Self::Error>;
 }
 
 /// Rssi trait allows polling for RSSI on the current channel
-/// 
+///
 /// Note that the radio should be in receive mode prior to polling for this.
 pub trait Rssi {
     /// Radio error
-    type Error;
-    
+    type Error: Debug;
+
     /// Fetch the current RSSI value from the radio
     /// Note that the radio MUST be in RX mode (or capable of measuring RSSI) when this is called
     /// or an error should be returned
@@ -174,14 +175,14 @@ pub trait Rssi {
 }
 
 /// State trait for configuring and reading radio states
-/// 
+///
 /// Note that drivers will internally configure and read radio states to manage
 /// radio operations.
 pub trait State {
     /// Radio state
-    type State;
+    type State: RadioState;
     /// Radio error type
-    type Error;
+    type Error: Debug;
 
     /// Set the radio to a specified state
     fn set_state(&mut self, state: Self::State) -> Result<(), Self::Error>;
@@ -190,7 +191,7 @@ pub trait State {
     fn get_state(&mut self) -> Result<Self::State, Self::Error>;
 }
 
-pub trait RadioState {
+pub trait RadioState: Debug {
     fn idle() -> Self;
 
     fn sleep() -> Self;
@@ -200,7 +201,7 @@ pub trait RadioState {
 /// and should not be interrupted
 pub trait Busy {
     /// Radio error type
-    type Error;
+    type Error: Debug;
 
     /// Indicates the radio is busy in the current state
     /// (for example, currently transmitting or receiving)
@@ -209,33 +210,33 @@ pub trait Busy {
 
 /// Interrupts trait allows for reading interrupt state from the device,
 /// as well as configuring interrupt pins.
-/// 
+///
 /// Note that drivers may internally use interrupts and interrupt states
 /// to manage radio operations.
 pub trait Interrupts {
     /// Interrupt object
-    type Irq;
+    type Irq: Debug;
     /// Radio error
-    type Error;
-    
+    type Error: Debug;
+
     /// Fetch any pending interrupts from the device
     /// If the clear option is set, this will also clear any returned flags
     fn get_interrupts(&mut self, clear: bool) -> Result<Self::Irq, Self::Error>;
 }
 
 /// Registers trait provides register level access to the radio device.
-/// 
+///
 /// This is generally too low level for use by higher abstractions, however,
 /// is provided for completeness.
 pub trait Registers<R: Copy> {
-    type Error;
+    type Error: Debug;
 
     /// Read a register value
     fn reg_read(&mut self, reg: R) -> Result<u8, Self::Error>;
 
     /// Write a register value
     fn reg_write(&mut self, reg: R, value: u8) -> Result<(), Self::Error>;
-    
+
     /// Update a register value
     fn reg_update(&mut self, reg: R, mask: u8, value: u8) -> Result<u8, Self::Error> {
         let existing = self.reg_read(reg)?;
@@ -245,10 +246,10 @@ pub trait Registers<R: Copy> {
     }
 }
 
-#[cfg(feature="structopt")]
+#[cfg(feature = "structopt")]
 use crate::std::str::FromStr;
 
-#[cfg(feature="structopt")]
+#[cfg(feature = "structopt")]
 fn duration_from_str(s: &str) -> Result<core::time::Duration, humantime::DurationError> {
     let d = humantime::Duration::from_str(s)?;
     Ok(*d)


### PR DESCRIPTION

- add `RadioState` and `ReceiveInfo` associated trait bounds
- move receive info from mutable argument to returned value using this
- update `blocking`, `nonblocking`, `mock` to match
- apply formatting

relates to #12, any opinions @henrikssn?