### PR TITLE
Return Info directly from Receive

### DIFF
--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -149,7 +149,7 @@ assert_eq!(&buff[..data.len()], &data);
 "##)]
 /// 
 pub trait BlockingReceive<I, E> {
-    fn do_receive(&mut self, buff: &mut [u8], info: &mut I, rx_options: BlockingOptions) -> Result<usize, BlockingError<E>>;
+    fn do_receive(&mut self, buff: &mut [u8], rx_options: BlockingOptions) -> Result<(usize, I), BlockingError<E>>;
 }
 
 impl <T, I, E> BlockingReceive<I, E> for T 
@@ -158,7 +158,7 @@ where
     I: core::fmt::Debug,
     E: core::fmt::Debug,
 {
-    fn do_receive(&mut self, buff: &mut [u8], info: &mut I, rx_options: BlockingOptions) -> Result<usize, BlockingError<E>> {
+    fn do_receive(&mut self, buff: &mut [u8], rx_options: BlockingOptions) -> Result<(usize, I), BlockingError<E>> {
         // Start receive mode
         self.start_receive()?;
 
@@ -166,8 +166,8 @@ where
         let mut c = 0;
         loop {
             if self.check_receive(true)? {
-                let n = self.get_received(info, buff)?;
-                return Ok(n)
+                let (n, info) = self.get_received(buff)?;
+                return Ok((n, info))
             }
 
             c += rx_options.poll_interval.as_micros();

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -5,7 +5,7 @@
 
 use structopt::StructOpt;
 use humantime::{Duration as HumanDuration};
-use embedded_hal::blocking::delay::DelayUs;
+use embedded_hal::delay::blocking::DelayUs;
 
 extern crate std;
 use std::prelude::v1::*;
@@ -105,7 +105,7 @@ where
 
         // Delay for repeated transmission or exit
         match &options.period {
-            Some(p) => radio.try_delay_us(p.as_micros() as u32).unwrap(),
+            Some(p) => radio.delay_us(p.as_micros() as u32).unwrap(),
             None => break,
         }
     }
@@ -235,7 +235,7 @@ where
             radio.start_receive()?;
         }
 
-        radio.try_delay_us(options.blocking_options.poll_interval.as_micros() as u32).unwrap();
+        radio.delay_us(options.blocking_options.poll_interval.as_micros() as u32).unwrap();
     }
 }
 
@@ -268,7 +268,7 @@ where
 
         radio.check_receive(true)?;
 
-        radio.try_delay_us(options.period.as_micros() as u32).unwrap();
+        radio.delay_us(options.period.as_micros() as u32).unwrap();
 
         if !options.continuous {
             break
@@ -334,7 +334,7 @@ where
             }
 
             // Wait for turnaround delay
-            radio.try_delay_us(options.delay.as_micros() as u32).unwrap();
+            radio.delay_us(options.delay.as_micros() as u32).unwrap();
 
             // Transmit respobnse
             radio.do_transmit(&buff[..n], options.blocking_options.clone())?;
@@ -344,7 +344,7 @@ where
         }
 
         // Wait for poll delay
-        radio.try_delay_us(options.blocking_options.poll_interval.as_micros() as u32).unwrap();
+        radio.delay_us(options.blocking_options.poll_interval.as_micros() as u32).unwrap();
     }
 }
 
@@ -443,7 +443,7 @@ where
         }
 
         // Wait for send delay
-        radio.try_delay_us(options.delay.as_micros() as u32).unwrap();
+        radio.delay_us(options.delay.as_micros() as u32).unwrap();
     }
 
     Ok(link_info)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ pub trait Receive {
     /// Radio error
     type Error;
     /// Packet received info
-    type Info;
+    type Info: ReceiveInfo;
 
     /// Set receiving on the specified channel
     /// 
@@ -81,7 +81,7 @@ pub trait Receive {
     /// 
     /// This copies received data into the provided buffer and returns the number of bytes received
     /// as well as information about the received packet
-    fn get_received(&mut self, info: &mut Self::Info, buff: &mut [u8]) -> Result<usize, Self::Error>;
+    fn get_received(&mut self, buff: &mut [u8]) -> Result<(usize, Self::Info), Self::Error>;
 }
 
 /// ReceiveInfo trait for receive information objects


### PR DESCRIPTION
This PR moves the `ReceiveInfo` from `Receive`'s `get_received` method from its parameters to the return type. Originally, one would need to create `Info::default()` and then have `get_received` alter it. Now, `get_received` has to create the `Info` itself. This removes the need for a `Default` trait bound, and simplifies the caller code a bit.

You mentioned GATs not being available as the reason `Info` was a parameter, but I'm not sure why, as I didn't use GATs here. :grin:

As such, take this PR with a grain of salt for now, but I would love to know how it can be improved!