### PR TITLE
Cleanup std/no-std features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ embedded-hal = "1.0.0-alpha.5"
 nb = "1.0.0"
 
 log = { version = "0.4.14", optional = true, default_features = false }
-defmt = { version = "*", optional = true }
+defmt = { version = "0.3.0", optional = true }
 
 humantime = { version = "2.0.1", optional = true }
 pcap-file = { version = "1.1.1", optional = true }
@@ -30,7 +30,7 @@ structopt = { version = "0.3.14", optional = true }
 async-std = { version = "1.4.0", optional = true }
 libc = { version = "0.2.71", optional = true }
 byteorder = { version = "1.3.4", optional = true }
-rolling-stats = { version = "0.3.0", optional = true }
+rolling-stats = { version = "0.5.0", optional = true }
 thiserror = { version = "1.0.30", optional = true }
 
 [dependencies.chrono]
@@ -38,7 +38,7 @@ version = "0.4.19"
 default_features = false
 
 [dependencies.embedded-hal-mock]
-version = "0.7.1"
+version = "0.8.0"
 optional = true
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,16 +11,17 @@ version = "0.10.0"
 all-features = true
 
 [features]
+std = []
 nonblocking = [ ]
 mock = [ "embedded-hal-mock" ]
-std = []
 helpers = [ "structopt", "humantime", "std", "pcap-file", "libc", "byteorder", "rolling-stats" ]
 default = []
 
 [dependencies]
 embedded-hal = "1.0.0-alpha.5"
 nb = "1.0.0"
-log = "0.4.14"
+
+log = { version = "0.4.14", default_features = false }
 
 humantime = { version = "2.0.1", optional = true }
 pcap-file = { version = "1.1.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.10.0"
 all-features = true
 
 [features]
-std = []
+std = [ "log" ]
 nonblocking = [ ]
 mock = [ "embedded-hal-mock" ]
 helpers = [ "structopt", "humantime", "std", "pcap-file", "libc", "byteorder", "rolling-stats" ]
@@ -21,7 +21,8 @@ default = []
 embedded-hal = "1.0.0-alpha.5"
 nb = "1.0.0"
 
-log = { version = "0.4.14", default_features = false }
+log = { version = "0.4.14", optional = true, default_features = false }
+defmt = { version = "*", optional = true }
 
 humantime = { version = "2.0.1", optional = true }
 pcap-file = { version = "1.1.1", optional = true }

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -9,13 +9,14 @@
 use core::fmt::Debug;
 use core::time::Duration;
 
+use log::debug;
 use embedded_hal::delay::blocking::DelayUs;
 
 #[cfg(feature = "structopt")]
 use structopt::StructOpt;
 
 #[cfg(feature = "std")]
-use crate::std::string::ToString;
+use std::string::ToString;
 
 use crate::{Receive, State, Transmit};
 

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -9,8 +9,8 @@
 use core::fmt::Debug;
 use core::time::Duration;
 
-use log::debug;
 use embedded_hal::delay::blocking::DelayUs;
+use log::debug;
 
 #[cfg(feature = "structopt")]
 use structopt::StructOpt;

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -11,10 +11,10 @@ use core::time::Duration;
 
 use embedded_hal::delay::blocking::DelayUs;
 
-#[cfg(feature="log")]
+#[cfg(feature = "log")]
 use log::debug;
 
-#[cfg(feature="defmt")]
+#[cfg(feature = "defmt")]
 use defmt::debug;
 
 #[cfg(feature = "structopt")]
@@ -28,7 +28,7 @@ use crate::{Receive, State, Transmit};
 /// BlockingOptions for blocking radio functions
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "structopt", derive(StructOpt))]
-#[cfg_attr(feature="defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct BlockingOptions {
     /// Interval for polling for device state
     #[cfg_attr(feature="structopt", structopt(long, default_value="100us", parse(try_from_str=crate::duration_from_str)))]
@@ -51,7 +51,7 @@ impl Default for BlockingOptions {
 /// BlockingError wraps radio error type to provie a `Timeout` variant
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "thiserror", derive(thiserror::Error))]
-#[cfg_attr(feature="defmt", derive(defmt::Format))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum BlockingError<E> {
     #[cfg_attr(feature = "thiserror", error("Inner: {0}"))]
     Inner(E),
@@ -118,7 +118,7 @@ where
         loop {
             // Check for transmit complete
             if self.check_transmit()? {
-                #[cfg(any(feature="log", feature="defmt"))]
+                #[cfg(any(feature = "log", feature = "defmt"))]
                 debug!("Blocking send complete");
                 break;
             }
@@ -126,7 +126,7 @@ where
             // Update poll time and timeout if overrun
             c += tx_options.poll_interval.as_micros();
             if c > t {
-                #[cfg(any(feature="log", feature="defmt"))]
+                #[cfg(any(feature = "log", feature = "defmt"))]
                 debug!("Blocking send timeout");
                 return Err(BlockingError::Timeout);
             }
@@ -210,7 +210,7 @@ where
 
             c += rx_options.poll_interval.as_micros();
             if c > t {
-                #[cfg(any(feature="log", feature="defmt"))]
+                #[cfg(any(feature = "log", feature = "defmt"))]
                 debug!("Blocking receive timeout");
                 return Err(BlockingError::Timeout);
             }
@@ -258,7 +258,7 @@ where
             // Timeout eventually
             c += options.poll_interval.as_micros();
             if c > t {
-                #[cfg(any(feature="log", feature="defmt"))]
+                #[cfg(any(feature = "log", feature = "defmt"))]
                 debug!("Blocking receive timeout");
                 return Err(BlockingError::Timeout);
             }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -3,11 +3,6 @@
 //! ## https://github.com/ryankurte/rust-radio
 //! ## Copyright 2020 Ryan Kurte
 
-use embedded_hal::delay::blocking::DelayUs;
-use humantime::Duration as HumanDuration;
-use structopt::StructOpt;
-
-extern crate std;
 use std::ffi::CString;
 use std::fs::{File, OpenOptions};
 use std::prelude::v1::*;
@@ -15,6 +10,12 @@ use std::string::String;
 use std::time::SystemTime;
 
 use libc::{self};
+
+use log::{debug, info};
+
+use embedded_hal::delay::blocking::DelayUs;
+use humantime::Duration as HumanDuration;
+use structopt::StructOpt;
 
 use byteorder::{ByteOrder, NetworkEndian};
 use pcap_file::{pcap::PcapHeader, DataLink, PcapWriter};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,24 +6,13 @@
 //! ## https://github.com/ryankurte/rust-radio
 //! ## Copyright 2020 Ryan Kurte
 
-#![no_std]
+// Set `no_std` where `std` feature is disabled
+#![cfg_attr(not(feature="std"), no_std)]
 
 use core::convert::TryFrom;
 use core::fmt::Debug;
 
-extern crate chrono;
-extern crate nb;
-
-#[macro_use]
-extern crate log;
-
-extern crate embedded_hal;
-
-#[cfg(feature = "std")]
-extern crate std;
-
 pub mod config;
-
 pub mod blocking;
 
 #[cfg(feature = "helpers")]
@@ -261,10 +250,10 @@ pub trait Registers<Word> {
     }
 }
 
-#[cfg(feature = "structopt")]
-use crate::std::str::FromStr;
+#[cfg(feature = "std")]
+use std::str::FromStr;
 
-#[cfg(feature = "structopt")]
+#[cfg(feature = "std")]
 fn duration_from_str(s: &str) -> Result<core::time::Duration, humantime::DurationError> {
     let d = humantime::Duration::from_str(s)?;
     Ok(*d)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,13 +7,13 @@
 //! ## Copyright 2020 Ryan Kurte
 
 // Set `no_std` where `std` feature is disabled
-#![cfg_attr(not(feature="std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 use core::convert::TryFrom;
 use core::fmt::Debug;
 
-pub mod config;
 pub mod blocking;
+pub mod config;
 
 #[cfg(feature = "helpers")]
 pub mod helpers;


### PR DESCRIPTION
fixes an issue with std/no_std, updates from `extern crate` to explicit includes.