### PR TITLE
pin e-h alpha

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ helpers = [ "structopt", "humantime", "std", "pcap-file", "libc", "byteorder", "
 default = []
 
 [dependencies]
-embedded-hal = "1.0.0-alpha.6"
+embedded-hal = "=1.0.0-alpha.6"
 nb = "1.0.0"
 
 log = { version = "0.4.14", optional = true, default_features = false }


### PR DESCRIPTION
Alphas dont follow semver and theres a new e-h alpha now which has breaking changes and is automatically being picked up in 10.0.

Obviously can update for the new e-h hal alpha as well, but seems best to get this patch and a new 10.1 release in first.

```
error[E0107]: this trait takes 0 generic arguments but 1 generic argument was supplied
  --> /home/jacob/.cargo/registry/src/github.com-1ecc6299db9ec823/radio-0.10.0/src/blocking.rs:97:30
   |
97 |     T: Transmit<Error = E> + DelayUs<u32>,
   |                              ^^^^^^^----- help: remove these generics
   |                              |
   |                              expected 0 generic arguments
   |
note: trait defined here, with 0 generic parameters
  --> /home/jacob/.cargo/registry/src/github.com-1ecc6299db9ec823/embedded-hal-1.0.0-alpha.6/src/delay.rs:14:15
   |
14 |     pub trait DelayUs {
   |               ^^^^^^^

error[E0107]: this trait takes 0 generic arguments but 1 generic argument was supplied
   --> /home/jacob/.cargo/registry/src/github.com-1ecc6299db9ec823/radio-0.10.0/src/blocking.rs:180:39
    |
180 |     T: Receive<Info = I, Error = E> + DelayUs<u32>,
    |                                       ^^^^^^^----- help: remove these generics
    |                                       |
    |                                       expected 0 generic arguments
    |
note: trait defined here, with 0 generic parameters
   --> /home/jacob/.cargo/registry/src/github.com-1ecc6299db9ec823/embedded-hal-1.0.0-alpha.6/src/delay.rs:14:15
    |
14  |     pub trait DelayUs {
    |               ^^^^^^^

error[E0107]: this trait takes 0 generic arguments but 1 generic argument was supplied
   --> /home/jacob/.cargo/registry/src/github.com-1ecc6299db9ec823/radio-0.10.0/src/blocking.rs:223:38
    |
223 |     T: State<State = S, Error = E> + DelayUs<u32>,
    |                                      ^^^^^^^----- help: remove these generics
    |                                      |
    |                                      expected 0 generic arguments
    |
note: trait defined here, with 0 generic parameters
   --> /home/jacob/.cargo/registry/src/github.com-1ecc6299db9ec823/embedded-hal-1.0.0-alpha.6/src/delay.rs:14:15
    |
14  |     pub trait DelayUs {
    |               ^^^^^^^

For more information about this error, try `rustc --explain E0107`.
error: could not compile `radio` due to 3 previous errors
warning: build failed, waiting for other jobs to finish...
error: build failed
```